### PR TITLE
Update cpt-archives.php

### DIFF
--- a/cpt-archives.php
+++ b/cpt-archives.php
@@ -42,7 +42,7 @@ class CPT_Archives {
 		add_filter( 'post_type_archive_title', array( $this, 'post_type_archive_title' ) );
 
 		add_action( 'post_updated', array( $this, 'post_updated' ), 10, 3 );
-		add_action( 'delete_post', array( $this, 'deleted_post' ) );
+		add_action( 'delete_post', array( $this, 'delete_post' ) );
 
 		// Prevent the cpt_archive post type rules from being registered.
 		add_filter( 'cpt_archive_rewrite_rules', '__return_empty_array' );


### PR DESCRIPTION
Resolved the following error by pointing delete_post action to existing function: Warning: call_user_func_array() expects parameter 1 to be a valid callback, class 'CPT_Archives' does not have a method 'deleted_post'
