### PR TITLE
Added Support for Timber Menus

### DIFF
--- a/php/PostType/ArchiveHookProvider.php
+++ b/php/PostType/ArchiveHookProvider.php
@@ -58,7 +58,7 @@ class ArchiveHookProvider {
 		$this->add_filter( 'post_type_link',              'post_type_link', 10, 3 );
 		$this->add_filter( 'post_type_archive_title',     'post_type_archive_title' );
 		$this->add_filter( 'get_the_archive_description', 'post_type_archive_description' );
-		$this->add_filter( 'wp_nav_menu_objects',         'nav_menu_classes', 10, 3 );
+		$this->add_filter( 'wp_get_nav_menu_items',       'nav_menu_classes', 10, 3 );
 		$this->add_action( 'admin_bar_menu',              'admin_bar_edit_menu', 80 );
 
 		// High priority makes archive links appear last in submenus.


### PR DESCRIPTION
Changed the filter that `nav_menu_classes` gets executed on to `wp_get_nav_menu_items` this means that the Classes are added much earlier in the execution.

Timber does not get the menu object at any point, instead going straight for the menu items and assembles the menu itself.  Therefore adding the needed CSS classes to the items, not the objects works in the case.